### PR TITLE
Add `promtool test` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,23 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Test Prometheus rules
+      uses: peimanja/promtool-github-actions@master
+      with:
+        promtool_actions_subcommand: 'test'
+        promtool_actions_files: 'prometheus/tests/*.yml'
+        promtool_actions_version: '2.14.0'
+        promtool_actions_comment: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
 
 Inputs configure Terraform GitHub Actions to perform different actions.
 
-* `promtool_actions_subcommand` - (Required) The Promtool subcommand to execute. Valid values are `rules` and `config`.
-* `promtool_actions_files` - (Required) Path to files. Can be something like `configs/*.yml` or `alert_rules/*.yml`. 
+* `promtool_actions_subcommand` - (Required) The Promtool subcommand to execute. Valid values are `rules`, `config` and `test`.
+* `promtool_actions_files` - (Required) Path to files. Can be something like `configs/*.yml`, `alert_rules/*.yml` or `tests/*.yml`.
 * `promtool_actions_version` - (Optional) The Promtool version to install and execute (Prometheus bundle version). The default is set to `latest` and the latest stable version will be pulled down automatically.
 * `promtool_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An exit code of `0` is considered a successful execution.
 
 ## Usage
 
-Promtool GitHub Actions are a single GitHub Action that executes different promtool subcommands depending on the content of the GitHub Actions YAML file. Right now only `rules` and `config` is supported which runs `promtool check rules` and `promtool check config` for the given files.
+Promtool GitHub Actions are a single GitHub Action that executes different promtool subcommands depending on the content of the GitHub Actions YAML file. Right now only `rules`, `config` or `test` is supported which runs `promtool check rules`, `promtool check config` or ` promtool test rules` for the given files.
 
 ```yaml
 name: Check Prometheus Alert rules

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,10 @@ branding:
   color: 'purple'
 inputs:
   promtool_actions_subcommand:
-    description: 'Promtool subcommand to execute (configs or rules).'
+    description: 'Promtool subcommand to execute (configs, rules or test).'
     required: true
   promtool_actions_files:
-    description: 'Path to files. Can be something like `configs/*.yml` or `alert_rules/*.yml`.'
+    description: 'Path to files. Can be something like `configs/*.yml`, `alert_rules/*.yml` or `tests/*.yml`.'
     required: true
   promtool_actions_version:
     description: 'Promtool version to install.'

--- a/src/main.sh
+++ b/src/main.sh
@@ -64,6 +64,8 @@ function main {
   scriptDir=$(dirname ${0})
   source ${scriptDir}/promtool_check_rules.sh
   source ${scriptDir}/promtool_check_config.sh
+  source ${scriptDir}/promtool_test_rules.sh
+
 
   parseInputs
   cd ${GITHUB_WORKSPACE}
@@ -76,6 +78,10 @@ function main {
     rules)
       installPromtool
       promtoolCheckRules ${*}
+      ;;
+    test)
+      installPromtool
+      promtoolTestRules ${*}
       ;;
     *)
       echo "Error: Must provide a valid value for promtool_subcommand"

--- a/src/promtool_test_rules.sh
+++ b/src/promtool_test_rules.sh
@@ -2,7 +2,7 @@
 
 function promtoolTestRules {
   echo "rules: info: testing if Prometheus rule files are valid or not"
-  testRulesOut=$(ls ${promFiles} |	xargs -I{}  promtool test rules {} ${*} 2>&1)
+  testRulesOut=$(ls ${promFiles} |	xargs -I{} promtool test rules {} ${*} 2>&1)
   testRulesExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.

--- a/src/promtool_test_rules.sh
+++ b/src/promtool_test_rules.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+function promtoolTestRules {
+  echo "rules: info: testing if Prometheus rule files are valid or not"
+  testRulesOut=$(ls ${promFiles} |	xargs -I{}  promtool test rules {} ${*} 2>&1)
+  testRulesExitCode=${?}
+
+  # Exit code of 0 indicates success. Print the output and exit.
+  if [ ${testRulesExitCode} -eq 0 ]; then
+    echo "testRules: info: Prometheus test succeeded."
+    echo "${testRulesOut}"
+    echo
+    testRulesCommentStatus="Success"
+  fi
+
+  # Exit code of !0 indicates failure.
+  if [ ${testRulesExitCode} -ne 0 ]; then
+    echo "testRules: error: Prometheus test failed."
+    echo "${testRulesOut}"
+    echo
+    testRulesCommentStatus="Failed"
+  fi
+
+  # Comment on the pull request if necessary.
+  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "${promtoolComment}" == "1" ]; then
+     testRulesCommentWrapper="#### \`promtool test rules\` ${testRulesCommentStatus}
+<details><summary>Show Output</summary>
+
+\`\`\`
+${testRulesOut}
+\`\`\`
+
+</details>
+
+*Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Files: \`${promFiles}\`*"
+
+    echo "testRules: info: creating JSON"
+    testRulesPayload=$(echo "${testRulesCommentWrapper}" | jq -R --slurp '{body: .}')
+    testRulesCommentsURL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
+    echo "testRules: info: commenting on the pull request"
+    echo "${testRulesPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${testRulesCommentsURL}" > /dev/null
+  fi
+
+  exit ${testRulesExitCode}
+}


### PR DESCRIPTION
Hi,

This a modest attempt to add the [`promtool test`](https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/) support on this action. 
The inputs are the same, except that you can now use `test` as the `promtool_actions_subcommand`. 
`promtool_actions_files` should point to one or multiple test files.
I've tried to mimic all the current behaviours, including commenting on the PR.

Happy to discuss any changes!

Thanks