### PR TITLE
Support promtool flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
       with:
         promtool_actions_subcommand: 'rules'
         promtool_actions_files: 'prometheus/alert_rules/*.yml'
+        promtool_actions_flags: '--lint-fatal'
         promtool_actions_version: '2.14.0'
         promtool_actions_comment: true
       env:
@@ -57,6 +58,7 @@ Inputs configure Terraform GitHub Actions to perform different actions.
 
 * `promtool_actions_subcommand` - (Required) The Promtool subcommand to execute. Valid values are `rules` and `config`.
 * `promtool_actions_files` - (Required) Path to files. Can be something like `configs/*.yml` or `alert_rules/*.yml`. 
+* `promtool_actions_flags` - (Optional) The Promtool flags.
 * `promtool_actions_version` - (Optional) The Promtool version to install and execute (Prometheus bundle version). The default is set to `latest` and the latest stable version will be pulled down automatically.
 * `promtool_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   promtool_actions_files:
     description: 'Path to files. Can be something like `configs/*.yml` or `alert_rules/*.yml`.'
     required: true
+  promtool_actions_flags:
+    description: 'Promtool flags.'
+    default: ''
   promtool_actions_version:
     description: 'Promtool version to install.'
     default: 'latest'

--- a/src/main.sh
+++ b/src/main.sh
@@ -16,6 +16,11 @@ function parseInputs {
     exit 1
   fi
 
+  promtoolFlags=""
+  if [ "${INPUT_PROMTOOL_ACTIONS_FLAGS}" != "" ]; then
+    promtoolFlags=${INPUT_PROMTOOL_ACTIONS_FLAGS}
+  fi
+
   # Optional inputs
   promtoolVersion="latest"
   if [ "${INPUT_PROMTOOL_ACTIONS_VERSION}" != "" ] || [ "${INPUT_PROMTOOL_ACTIONS_VERSION}" != "latest" ]; then

--- a/src/promtool_check_config.sh
+++ b/src/promtool_check_config.sh
@@ -2,7 +2,7 @@
 
 function promtoolCheckConfig {
   echo "rules: info: checking if Prometheus config files are valid or not"
-  checkconfigOut=$(promtool check config ${promFiles} ${*} 2>&1)
+  checkconfigOut=$(promtool check config ${promtoolFlags} ${promFiles} ${*} 2>&1)
   checkconfigExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.

--- a/src/promtool_check_rules.sh
+++ b/src/promtool_check_rules.sh
@@ -2,7 +2,7 @@
 
 function promtoolCheckRules {
   echo "rules: info: checking if Prometheus alert rule files are valid or not"
-  checkRulesOut=$(promtool check rules ${promFiles} ${*} 2>&1)
+  checkRulesOut=$(promtool check rules ${promtoolFlags} ${promFiles} ${*} 2>&1)
   checkRulesExitCode=${?}
 
   # Exit code of 0 indicates success. Print the output and exit.


### PR DESCRIPTION
There could be a need to use promtool flags.
For example, `--lint-fatal` flag to do not allow duplicate alerts.
(this used to work differently before `2.36.1` - [1](https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md#2361--2022-06-09), [2](https://github.com/prometheus/prometheus/pull/10840))