### PR TITLE
add shopt -s globstar

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+shopt -s globstar
+
 function parseInputs {
   # Required inputs
   if [ "${INPUT_PROMTOOL_ACTIONS_FILES}" != "" ]; then


### PR DESCRIPTION
This would enable globstar support on promtool_actions_files parameters like

```yaml
- name: Check Prometheus alert rules
      uses: peimanja/promtool-github-actions@master
      with:
        promtool_actions_subcommand: 'rules'
        promtool_actions_files: '**/prometheus-rules.yaml'
        promtool_actions_version: '2.14.0'
```